### PR TITLE
[BUG] fix extra attributes prefixing with nilclass

### DIFF
--- a/lib/form_object/base.rb
+++ b/lib/form_object/base.rb
@@ -455,6 +455,8 @@ module FormObject
     # @param pluralize determines if the prefix is going to be plural or not [Boolean]
     # @param model ActiveRecord class [ActiveRecord]
     def model_prefix(model, pluralize: false)
+      return nil if model.is_a?(NilClass)
+
       if pluralize
         instance_of_model(model).class.name.pluralize.gsub('::','_').underscore
       else

--- a/lib/multi_model_wizard/version.rb
+++ b/lib/multi_model_wizard/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MultiModelWizard
-  VERSION = '0.1.0'
+  VERSION = '0.1.0.1'
 end

--- a/spec/form_object/base_spec.rb
+++ b/spec/form_object/base_spec.rb
@@ -271,7 +271,21 @@ RSpec.describe FormObject::Base do
     end
   end
 
-  describe '#add_multiple_instance_model' do
+  describe '#validate_multiple_instance_model' do
+    context 'when data is a hash' do
+      it 'returns a boolean based on all the instances validity' do
+        car = { kind: 'car' }.stringify_keys
+        car_two = { kind: 'car', manufacturer_id: 1 }.stringify_keys
+        form = CustomVehicleForm.create_form do |f| 
+          f.add_multiple_instance_model attribute_name: 'cars', model: Car, instances: []
+        end
+
+        form.set_attributes({cars: [car, car_two]})
+
+        expect(form.validate_multiple_instance_model(:cars)).to eq(false)
+      end
+    end
+
     it 'returns a boolean based on all the instances validity' do
       car = Car.new(kind: 'car')
       car_two = Car.new(kind: 'car', manufacturer_id: 1)
@@ -352,6 +366,14 @@ RSpec.describe FormObject::Base do
       expect { form.add_extra_attributes(attributes: [:country_of_origin, 'designer']) }.to \
         raise_error(an_instance_of(ArgumentError).and \
         having_attributes(message: 'All attributes must be Symbols'))
+    end
+
+    it 'sets attributes with no prefix if there is no prefix provided' do
+      form = CustomVehicleForm.create_form do |f| 
+        f.add_extra_attributes attributes: [:country_of_origin]
+      end
+
+      expect(form.country_of_origin).to eq(nil)
     end
   end
 


### PR DESCRIPTION
[BUG] fix extra attributes prefixing with nilclass

**Problem**
when creating a form and you use the `add extra_attributes` method without a prefix the gem will prefix the attributes with `nil_class_my_attribute_name`

```
      form = CustomVehicleForm.create_form do |f| 
        f.add_extra_attributes attributes: [:country_of_origin]
      end

     > form.country_of_origin
     # => this will throw a no method error and suggest using nil_class_country_of_origin
```



